### PR TITLE
Update environment.yaml and fix testing issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
             -   "*"
     pull_request:
         branches:
-            -   "*"
+            -   "master"
 
 jobs:
     build:
@@ -14,7 +14,9 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-            -   uses: actions/checkout@v2
+            -   name: checkout
+                uses: actions/checkout@v2
+
             -   name: Install conda
                 uses: goanpeca/setup-miniconda@v1
                 with:

--- a/.github/workflows/verify_pre-commit.yaml
+++ b/.github/workflows/verify_pre-commit.yaml
@@ -1,4 +1,4 @@
-name: pre-commit
+name: Run all pre-commit checks one more time
 
 on:
     push:
@@ -14,9 +14,11 @@ jobs:
         steps:
             - name: checkout
               uses: actions/checkout@v2
+
             - name: set up python
               uses: actions/setup-python@v2
               with:
                   python-version: 3.8
+
             - name: Run pre-commit
               uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
             -   id: check-yaml
 
     -   repo: https://github.com/ambv/black
-        rev: 20.8b1
+        rev: 19.10b0 # consistent with conda environment
         hooks:
             -   id: black
                 args: []

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ update the environment with
 $ conda env update -f environments/environment.yaml
 ```
 
+If the `env update` command fails, you can remove the environment and re-create it:
+
+```
+$ conda env remove --name hires-marbl
+$ conda env create -f environments/environment.yaml
+```
+
 ### Use `pre-commit` to test code before commiting
 
 Please take advantage of the pre-commit package to ensure that `black` is run before commiting:
@@ -31,20 +38,13 @@ $ pre-commit run -a                  # check all the files currently in the repo
 ```
 
 The pre-commit package is already installed via the `hires-marbl` conda environment.
-There is a github action to run `black` on all pull requests,
-but running it locally via-pre-commit will reduce the number of failed actions.
+There is a github action to run these checks on all pull requests,
+but running them locally via-pre-commit will reduce the number of failed actions.
 NOTE: for some reason, to properly install `pre-commit` on the CISL systems,
 the above command must be run from `casper` rather than `cheyenne`.
 
 Note that pre-commit creates a virtual environment using specific tags of each package.
-To ensure pre-commit is testing with the latest releases, it is necessary to run
-
-```
-$ pre-commit autoupdate
-$ pre-commit install --install-hooks # set up pre-commit
-```
-
-from time to time.
+As newer versions of `black` become available on `conda-forge`, we will update the pre-commit environment.
 
 ### Run `pytest` after modifying python in `utils/`
 

--- a/environments/environment.yaml
+++ b/environments/environment.yaml
@@ -5,6 +5,7 @@ channels:
     - defaults
 
 dependencies:
+    - black=19.10b0
     - bottleneck
     - cartopy
     - cf_units
@@ -33,6 +34,7 @@ dependencies:
     - pint
     - pip
     - pop-tools
+    - pre-commit
     - pytest
     - python
     - scipy
@@ -50,4 +52,3 @@ dependencies:
     - zarr
     - pip:
         - ncar-jobqueue
-        - black


### PR DESCRIPTION
When resolving conflicts after merging Matt's updated environment file, I
forgot to add make sure pre-commit is on the list.

Also, Keith and I were having lots of trouble running conda env update because
we were getting black from pypi, so I moved black back to the list of packages
to get via conda. I hardcoded a version number and updated the pre-commit
config file to use the same version we get from conda. This led me to remove
some notes about pre-commit autoupdate from the README.